### PR TITLE
npn ci breaks in many cases

### DIFF
--- a/deployment/build-s3-dist.sh
+++ b/deployment/build-s3-dist.sh
@@ -74,7 +74,7 @@ cp sam.yaml $template_dist_dir/backend.template
 # Step 3/5: Build client (React)
 ######################################################
 cd $source_dir/client || exit
-npm ci
+npm install --legacy-peer-deps
 # Download ML models
 curl -o public/weights/tiny_face_detector_model-shard1.shard -kL https://github.com/justadudewhohacks/face-api.js/blob/a86f011d72124e5fb93e59d5c4ab98f699dd5c9c/weights/tiny_face_detector_model-shard1?raw=true
 echo 'f3020debaf078347b5caaff4bf6dce2f379d20bc *public/weights/tiny_face_detector_model-shard1.shard' | shasum -c


### PR DESCRIPTION
npn ci breaks in many cases , suggesting to update to "npm install --legacy-peer-deps"

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
